### PR TITLE
Correctly deploy favicon

### DIFF
--- a/now.json
+++ b/now.json
@@ -2,5 +2,8 @@
   "version": 2,
   "alias": ["ergday"],
   "regions": ["bru"],
-  "builds": [{ "src": "next.config.js", "use": "@now/next" }]
+  "builds": [
+    { "src": "next.config.js", "use": "@now/next" },
+    { "src": "static/favicon.ico", "use": "@now/static" }
+  ]
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -56,7 +56,7 @@ export default class extends Component {
       <div>
         <Head>
           <title>Workout of the day</title>
-          <link rel="icon" href="/static/favicon.ico" type="image/x-icon" />
+          <link rel="icon" href="/static/favicon.ico" />
         </Head>
         <h1>Workout of the day</h1>
         <Workout workout={this.props.workout} />


### PR DESCRIPTION
Looks like we need to deploy it separately with `now` version 2

Closes #9 